### PR TITLE
Version bump, upgrade to newer /sys/fs layout

### DIFF
--- a/bunhax.rb
+++ b/bunhax.rb
@@ -10,8 +10,8 @@ require "#{$app_path}/parse.rb"
 
 #init section ffs
 $EndProg	= false #we dont want bunhax to close right away do we?
-$version	= "0.2.6-rb" #using this for interactive mode...
-$cpuset_dir	= "/dev/cpuset"
+$version	= "0.2.7-rb" #using this for interactive mode...
+$cpuset_dir	= "/sys/fs/cgroup/cpuset"
 $proc_dir	= "/proc"
 $conf		= "#{$app_path}/.bunhax.conf"
 $setlist	= []

--- a/changelog
+++ b/changelog
@@ -2,6 +2,9 @@ Changes for bunhax...
 
 Reminder: All files must be placed in same directory unless you edit the source (please dont). Requires root access.
 
+Changes * 0.2.7-rb
+*********************************
+- Version bump, upgrade to newer /sys/fs layout
 
 Changes * 0.2.6-rb
 *********************************

--- a/cpuset.rb
+++ b/cpuset.rb
@@ -31,11 +31,11 @@ class Cpuset
                 if !FileTest.exist?($cpuset_dir + "/" + cpuset)
                         puts "#{$head} Good, doesnt exist. Creating..."
                         Dir.mkdir($cpuset_dir + "/" + cpuset)
-			edit_file = ($cpuset_dir + "/" + cpuset + "/mems")
+			edit_file = ($cpuset_dir + "/" + cpuset + "/cpuset.mems")
 			`/bin/echo #{mems} > #{edit_file}`
-			edit_file = ($cpuset_dir + "/" + cpuset + "/cpus")
+			edit_file = ($cpuset_dir + "/" + cpuset + "/cpuset.cpus")
 			`/bin/echo #{cpus} > #{edit_file}`
-			`/bin/echo 1 > #{$cpuset_dir + "/" + cpuset + "/cpu_exclusive"}`
+			`/bin/echo 1 > #{$cpuset_dir + "/" + cpuset + "/cpuset.cpu_exclusive"}`
                 else
                         puts "#{$head} That cpuset already exists!"
                 end
@@ -64,10 +64,10 @@ class Cpuset
 			puts "#{$head} Error #{$c1}->#{$c2} empty cpuset name"
 		else
 			#lets get the current settings for cpus and mems
-			cpusFile = File.new($cpuset_dir + "/" + cpuset + "/cpus", "r")
+			cpusFile = File.new($cpuset_dir + "/" + cpuset + "/cpuset.cpus", "r")
 			oldcpus = cpusFile.readline.strip
 			cpusFile.close
-			memsFile = File.new($cpuset_dir + "/" + cpuset + "/mems", "r")
+			memsFile = File.new($cpuset_dir + "/" + cpuset + "/cpuset.mems", "r")
 			oldmems = memsFile.readline.strip
 			memsFile.close
 
@@ -85,10 +85,10 @@ class Cpuset
 	end
 	def Cpuset.edit(cpuset, cpus, mems)
 		if FileTest.exist?($cpuset_dir + "/" + cpuset)
-			cpusFile = File.new($cpuset_dir + "/" + cpuset + "/cpus", "w+")
+			cpusFile = File.new($cpuset_dir + "/" + cpuset + "/cpuset.cpus", "w+")
 			cpusFile.puts(cpus)
 			cpusFile.close
-			memsFile = File.new($cpuset_dir + "/" + cpuset + "/mems", "w+")
+			memsFile = File.new($cpuset_dir + "/" + cpuset + "/cpuset.mems", "w+")
 			memsFile.puts(mems)
 			memsFile.close
 			puts "#{cpuset}: now using CPU: #{cpus} and MEM: #{mems}"
@@ -125,8 +125,8 @@ class Cpuset
 	def Cpuset.getinfo(cpuset)
 		getdir = $cpuset_dir + "/" + cpuset
 		gettasks = getdir + "/tasks"
-		getcpus = getdir + "/cpus"
-		getmems = getdir + "/mems"
+		getcpus = getdir + "/cpuset.cpus"
+		getmems = getdir + "/cpuset.mems"
 		puts "#{$head} Error -> unable to locate file: #{gettasks}" if !FileTest.exist?(gettasks)
 		puts "#{$head} Error -> unable to locate file: #{getcpus}" if !FileTest.exist?(getcpus)
 		puts "#{$head} Error -> unable to locate file: #{getmems}" if !FileTest.exist?(getmems)

--- a/sync.rb
+++ b/sync.rb
@@ -77,6 +77,6 @@ class Sync
 	end
 	def Sync.mkmnt
 		Dir.mkdir($cpuset_dir)
-		$mounted = true if `mount -t cpuset cpuset /dev/cpuset`
+		$mounted = true if `mount -t cpuset cpuset /sys/fs/cgroup/cpuset`
 	end
 end

--- a/task.rb
+++ b/task.rb
@@ -55,7 +55,9 @@ class Task
                 # we already have the pid, and we are outputing it differently later so only grab the app.name
 		a = pid_stat.split(' ')
                 pidName = (a[2] =~ /\)$/) ? "#{a[1]} #{a[2]}" : a[1]
-                pidcpu = (a.length == 44) ? a[38] : a[39]
+                ### this used to work but now gives irregular results
+                ###pidcpu = (a.length == 44) ? a[38] : a[39]
+                pidcpu = a[38]
                 #output in a nice format.. with colours!
                 puts "#{pid} #{$c1}-#{$c2} #{pidName} #{$c1}-#{$c2} #{pidcpu}"
         end


### PR DESCRIPTION
Gentoo openrc now mounts cgroups to /sys/fs/cgroup/&lt;type&gt;.  This update changes the program to follow the new layout.  Also potentially fixes a bug with the current-cpu field in the print-tasks command.
